### PR TITLE
Fix bossbar error

### DIFF
--- a/src/aieuo/mineflow/utils/Bossbar.php
+++ b/src/aieuo/mineflow/utils/Bossbar.php
@@ -66,7 +66,7 @@ class Bossbar {
 
         $pk = new AddActorPacket();
         $pk->entityRuntimeId = $bar->getEntityId();
-        $pk->type = EntityIds::SHULKER;
+        $pk->type = AddActorPacket::LEGACY_ID_MAP_BC[EntityIds::SHULKER];
         $pk->metadata = [Entity::DATA_FLAGS => [Entity::DATA_TYPE_LONG, (1 << Entity::DATA_FLAG_INVISIBLE) | (1 << Entity::DATA_FLAG_IMMOBILE)], Entity::DATA_NAMETAG => [Entity::DATA_TYPE_STRING, $title]];
         $pk->position = new Vector3(0, 0, 0);
         $player->sendDataPacket($pk);


### PR DESCRIPTION
以下のバグを修正。
バグ発生 PocketMine-MP コミット: https://github.com/pmmp/PocketMine-MP/commit/c19ab976107446b629e586add9983db83496f0e6

もし、私を貢献者リストに載せたくない場合、手動マージにて問題ございません。

```
2020-06-05 [18:57:03] [Server thread/CRITICAL]: TypeError: "Argument 1 passed to pocketmine\network\mcpe\NetworkBinaryStream::putString() must be of the type string, int given, called in phar://I:/Owner/Desktop/pmmp/PocketMine-MP.phar/src/pocketmine/network/mcpe/protocol/AddActorPacket.php on line 211" (EXCEPTION) in "src/pocketmine/network/mcpe/NetworkBinaryStream" at line 62
2020-06-05 [18:57:03] [Server thread/DEBUG]: #0 src/pocketmine/network/mcpe/protocol/AddActorPacket(211): pocketmine\network\mcpe\NetworkBinaryStream->putString(integer 54)
2020-06-05 [18:57:03] [Server thread/DEBUG]: #1 src/pocketmine/network/mcpe/protocol/DataPacket(127): pocketmine\network\mcpe\protocol\AddActorPacket->encodePayload()
2020-06-05 [18:57:03] [Server thread/DEBUG]: #2 src/pocketmine/network/mcpe/RakLibInterface(244): pocketmine\network\mcpe\protocol\DataPacket->encode()
2020-06-05 [18:57:03] [Server thread/DEBUG]: #3 src/pocketmine/Player(3235): pocketmine\network\mcpe\RakLibInterface->putPacket(object pocketmine\Player, object pocketmine\network\mcpe\protocol\AddActorPacket, boolean , boolean )
2020-06-05 [18:57:03] [Server thread/DEBUG]: #4 plugins/Mineflow/src/aieuo/mineflow/utils/Bossbar(72): pocketmine\Player->sendDataPacket(object pocketmine\network\mcpe\protocol\AddActorPacket)
2020-06-05 [18:57:03] [Server thread/DEBUG]: #5 plugins/Mineflow/src/aieuo/mineflow/flowItem/action/ShowBossbar(99): aieuo\mineflow\utils\Bossbar::add(object pocketmine\Player, string[1] 1, string[2] 20, double 20, double 1)
2020-06-05 [18:57:03] [Server thread/DEBUG]: #6 plugins/Mineflow/src/aieuo/mineflow/flowItem/action/ActionContainerTrait(79): aieuo\mineflow\flowItem\action\ShowBossbar->execute(object aieuo\mineflow\recipe\Recipe)
2020-06-05 [18:57:03] [Server thread/DEBUG]: #7 plugins/Mineflow/src/aieuo/mineflow/recipe/Recipe(229): aieuo\mineflow\recipe\Recipe->executeActions(object aieuo\mineflow\recipe\Recipe, NULL , integer 0)
2020-06-05 [18:57:03] [Server thread/DEBUG]: #8 plugins/Mineflow/src/aieuo/mineflow/recipe/Recipe(209): aieuo\mineflow\recipe\Recipe->execute(array[0])
2020-06-05 [18:57:03] [Server thread/DEBUG]: #9 plugins/Mineflow/src/aieuo/mineflow/ui/RecipeForm(204): aieuo\mineflow\recipe\Recipe->executeAllTargets(object pocketmine\Player)
2020-06-05 [18:57:03] [Server thread/DEBUG]: #10 (): aieuo\mineflow\ui\RecipeForm->aieuo\mineflow\ui\{closure}(object pocketmine\Player, integer 3, object aieuo\mineflow\recipe\Recipe)
2020-06-05 [18:57:03] [Server thread/DEBUG]: #11 plugins/Mineflow/src/aieuo/mineflow/formAPI/Form(194): call_user_func_array(object Closure, array[3])
2020-06-05 [18:57:03] [Server thread/DEBUG]: #12 src/pocketmine/Player(3539): aieuo\mineflow\formAPI\Form->handleResponse(object pocketmine\Player, integer 3)
2020-06-05 [18:57:03] [Server thread/DEBUG]: #13 src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter(264): pocketmine\Player->onFormSubmit(integer 14, integer 3)
2020-06-05 [18:57:03] [Server thread/DEBUG]: #14 src/pocketmine/network/mcpe/protocol/ModalFormResponsePacket(49): pocketmine\network\mcpe\PlayerNetworkSessionAdapter->handleModalFormResponse(object pocketmine\network\mcpe\protocol\ModalFormResponsePacket)
2020-06-05 [18:57:03] [Server thread/DEBUG]: #15 src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter(110): pocketmine\network\mcpe\protocol\ModalFormResponsePacket->handle(object pocketmine\network\mcpe\PlayerNetworkSessionAdapter)
```