### PR TITLE
「コンソールからコマンドを実行する」を実行した際のエラーを修正

### DIFF
--- a/src/aieuo/mineflow/command/MineflowConsoleCommandSender.php
+++ b/src/aieuo/mineflow/command/MineflowConsoleCommandSender.php
@@ -17,6 +17,9 @@ class MineflowConsoleCommandSender extends ConsoleCommandSender {
     }
 
     public static function getInstance(): self {
+        if (self::$instance === null) {
+            self::$instance = new self;
+        }
         return self::$instance;
     }
 


### PR DESCRIPTION
## 概要
「コンソールからコマンドを実行する」を実行した際に発生するTypeErrorを修正します。

## 環境
### PocketMine-MPのバージョン
`このサーバーは Minecraft: Bedrock Edition v1.16.20（プロトコルバージョン 408）用 PocketMine-MP 3.15.1 を実行しています`
### エラーの再現に使用したビルド
[Dev Build #120](https://poggit.pmmp.io/ci/aieuo/Mineflow/Mineflow/dev:120)

### エラーの再現に使用したレシピ
これを適用してサーバーに参加します。
<details><summary>PR用-1.json</summary><div>

```json
{
    "name": "PR用-1",
    "author": "PJZ9n",
    "detail": "",
    "plugin_version": "1.0.0",
    "recipes": [
        {
            "name": "サーバーに参加した時コンソールからsayコマンドを実行する",
            "group": "",
            "author": "PJZ9n",
            "actions": [
                {
                    "id": "commandConsole",
                    "contents": [
                        "say コンソールからコマンドを実行しています！"
                    ]
                }
            ],
            "triggers": [
                {
                    "type": "event",
                    "key": "pocketmine\\event\\player\\PlayerJoinEvent",
                    "subKey": ""
                }
            ],
            "target": {
                "type": 0,
                "options": []
            },
            "arguments": [],
            "returnValues": []
        }
    ],
    "commands": [],
    "forms": [],
    "configs": {
        "test": []
    }
}
```
</div></details>

## エラー文
```
[Server thread/CRITICAL]: TypeError: "Return value of aieuo\mineflow\command\MineflowConsoleCommandSender::getInstance() must be an instance of aieuo\mineflow\command\MineflowConsoleCommandSender, null returned" (EXCEPTION) in "plugins/Mineflow/src/aieuo/mineflow/command/MineflowConsoleCommandSender" at line 20
```

<details><summary>スタックトレース</summary><div>

```
[Server thread/CRITICAL]: #0 plugins/Mineflow/src/aieuo/mineflow/flowItem/action/CommandConsole(59): aieuo\mineflow\command\MineflowConsoleCommandSender::getInstance()
[Server thread/CRITICAL]: #1 plugins/Mineflow/src/aieuo/mineflow/flowItem/FlowItemContainerTrait(82): aieuo\mineflow\flowItem\action\CommandConsole->execute(object aieuo\mineflow\recipe\Recipe)
[Server thread/CRITICAL]: #2 (): aieuo\mineflow\recipe\Recipe->executeAll(object aieuo\mineflow\recipe\Recipe, string[6] action)
[Server thread/CRITICAL]: #3 plugins/Mineflow/src/aieuo/mineflow/recipe/Recipe(262): Generator->next()
[Server thread/CRITICAL]: #4 plugins/Mineflow/src/aieuo/mineflow/recipe/Recipe(233): aieuo\mineflow\recipe\Recipe->execute(array[0])
[Server thread/CRITICAL]: #5 plugins/Mineflow/src/aieuo/mineflow/recipe/RecipeContainer(50): aieuo\mineflow\recipe\Recipe->executeAllTargets(object pocketmine\Player, array[10], object pocketmine\event\player\PlayerChatEvent)
[Server thread/CRITICAL]: #6 plugins/Mineflow/src/aieuo/mineflow/event/EventTriggerListener(51): aieuo\mineflow\recipe\RecipeContainer->executeAll(object pocketmine\Player, array[2], object pocketmine\event\player\PlayerChatEvent)
[Server thread/CRITICAL]: #7 src/pocketmine/plugin/MethodEventExecutor(42): aieuo\mineflow\event\EventTriggerListener->onEvent(object pocketmine\event\player\PlayerChatEvent)
[Server thread/CRITICAL]: #8 src/pocketmine/plugin/RegisteredListener(80): pocketmine\plugin\MethodEventExecutor->execute(object aieuo\mineflow\event\EventTriggerListener, object pocketmine\event\player\PlayerChatEvent)
[Server thread/CRITICAL]: #9 src/pocketmine/event/Event(88): pocketmine\plugin\RegisteredListener->callEvent(object pocketmine\event\player\PlayerChatEvent)
[Server thread/CRITICAL]: #10 src/pocketmine/Player(2320): pocketmine\event\Event->call()
[Server thread/CRITICAL]: #11 src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter(131): pocketmine\Player->chat(string[1] a)
[Server thread/CRITICAL]: #12 src/pocketmine/network/mcpe/protocol/TextPacket(126): pocketmine\network\mcpe\PlayerNetworkSessionAdapter->handleText(object pocketmine\network\mcpe\protocol\TextPacket)
[Server thread/CRITICAL]: #13 src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter(110): pocketmine\network\mcpe\protocol\TextPacket->handle(object pocketmine\network\mcpe\PlayerNetworkSessionAdapter)
[Server thread/CRITICAL]: #14 src/pocketmine/network/mcpe/protocol/BatchPacket(127): pocketmine\network\mcpe\PlayerNetworkSessionAdapter->handleDataPacket(object pocketmine\network\mcpe\protocol\TextPacket)
[Server thread/CRITICAL]: #15 src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter(110): pocketmine\network\mcpe\protocol\BatchPacket->handle(object pocketmine\network\mcpe\PlayerNetworkSessionAdapter)
[Server thread/CRITICAL]: #16 src/pocketmine/Player(3255): pocketmine\network\mcpe\PlayerNetworkSessionAdapter->handleDataPacket(object pocketmine\network\mcpe\protocol\BatchPacket)
[Server thread/CRITICAL]: #17 src/pocketmine/network/mcpe/RakLibInterface(169): pocketmine\Player->handleDataPacket(object pocketmine\network\mcpe\protocol\BatchPacket)
[Server thread/CRITICAL]: #18 vendor/pocketmine/raklib/src/server/ServerHandler(95): pocketmine\network\mcpe\RakLibInterface->handleEncapsulated(string[19] 192.168.2.185 57523, object raklib\protocol\EncapsulatedPacket, integer 0)
[Server thread/CRITICAL]: #19 src/pocketmine/network/mcpe/RakLibInterface(109): raklib\server\ServerHandler->handlePacket()
[Server thread/CRITICAL]: #20 src/pocketmine/network/mcpe/RakLibInterface(99): pocketmine\network\mcpe\RakLibInterface->process()
[Server thread/CRITICAL]: #21 vendor/pocketmine/snooze/src/SleeperHandler(123): pocketmine\network\mcpe\RakLibInterface->pocketmine\network\mcpe\{closure}()
[Server thread/CRITICAL]: #22 vendor/pocketmine/snooze/src/SleeperHandler(85): pocketmine\snooze\SleeperHandler->processNotifications()
[Server thread/CRITICAL]: #23 src/pocketmine/Server(2157): pocketmine\snooze\SleeperHandler->sleepUntil(double 1601890408.1693)
[Server thread/CRITICAL]: #24 src/pocketmine/Server(1994): pocketmine\Server->tickProcessor()
[Server thread/CRITICAL]: #25 src/pocketmine/Server(1588): pocketmine\Server->start()
[Server thread/CRITICAL]: #26 src/pocketmine/PocketMine(273): pocketmine\Server->__construct(object BaseClassLoader, object pocketmine\utils\MainLogger, string[16] /path/to/directory/, string[24] /path/to/directory/plugins/)
[Server thread/CRITICAL]: #27 src/pocketmine/PocketMine(304): pocketmine\server()
[Server thread/CRITICAL]: #28 (11): require(string[64] phar:///path/to/directory/PocketMine-MP.phar/src/pocketmine/PocketMine.php)
```
</div></details>
