### PR TITLE
エラー時に二重でflowItem名が表示される問題を修正

### DIFF
--- a/resources/eng.ini
+++ b/resources/eng.ini
@@ -1,7 +1,7 @@
 language.name=English
 language.selected=Selected {%0} as the base language
 
-invalid.contents=§c[{%0}] invalid data
+invalid.contents=§cinvalid data
 
 economy.found=Selected {%0} as the economy plugin
 economy.notfound=Economy plugin not found

--- a/resources/jpn.ini
+++ b/resources/jpn.ini
@@ -1,7 +1,7 @@
 language.name=日本語
 language.selected=言語を{%0}に設定しました
 
-invalid.contents=§c[{%0}] 正しく入力できていません
+invalid.contents=§c正しく入力できていません
 
 economy.found={%0}を見つけました
 economy.notfound=経済システムプラグインが見つかりません

--- a/src/aieuo/mineflow/flowItem/FlowItem.php
+++ b/src/aieuo/mineflow/flowItem/FlowItem.php
@@ -99,7 +99,7 @@ abstract class FlowItem implements \JsonSerializable, FlowItemIds {
 
     public function throwIfCannotExecute(): void {
         if (!$this->isDataValid()) {
-            $message = Language::get("invalid.contents", [$this->getName()]);
+            $message = Language::get("invalid.contents");
             throw new InvalidFlowValueException($this->getName(), $message);
         }
     }


### PR DESCRIPTION
## 概要
タイトルの通りです。

- 期待される結果: §c[flowItem名] 正しく入力できていません
- 実際の結果: §c[flowItem名] §c[flowItem名] 正しく入力できていません

## 環境
### PocketMine-MPのバージョン
`このサーバーは Minecraft: Bedrock Edition v1.16.20（プロトコルバージョン 408）用 PocketMine-MP 3.15.1 を実行しています`
### 不具合の再現に使用したビルド
[Dev Build #124](https://poggit.pmmp.io/ci/aieuo/Mineflow/Mineflow/dev:124)
