### PR TITLE
Fix missing phpdoc in FlowItemFactory

### DIFF
--- a/src/aieuo/mineflow/flowItem/FlowItemFactory.php
+++ b/src/aieuo/mineflow/flowItem/FlowItemFactory.php
@@ -215,6 +215,7 @@ class FlowItemFactory {
 
     /** @var FlowItem[] */
     private static array $list = [];
+    /** @var FlowItem[] */
     private static array $aliases = [];
 
     public static function init(): void {


### PR DESCRIPTION
※ `FlowItemFactory::registerAlias()` の引数型が `FlowItem` だったので、 `FlowItemAlias[]` ではなく `FlowItem[]` としました。