### PR TITLE
Reset rawData when recipe is saved

### DIFF
--- a/src/aieuo/mineflow/recipe/Recipe.php
+++ b/src/aieuo/mineflow/recipe/Recipe.php
@@ -337,6 +337,7 @@ class Recipe implements \JsonSerializable, FlowItemContainer {
 
         $json = json_encode($this, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_BIGINT_AS_STRING);
         if ($json === $this->getRawData()) return;
+        $this->setRawData($json);
 
         try {
             FileSystem::safeFilePutContents($path, $json);

--- a/src/aieuo/mineflow/recipe/Recipe.php
+++ b/src/aieuo/mineflow/recipe/Recipe.php
@@ -337,10 +337,10 @@ class Recipe implements \JsonSerializable, FlowItemContainer {
 
         $json = json_encode($this, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_BIGINT_AS_STRING);
         if ($json === $this->getRawData()) return;
-        $this->setRawData($json);
 
         try {
             FileSystem::safeFilePutContents($path, $json);
+            $this->setRawData($json);
         } catch(\RuntimeException $e) {
             Main::getInstance()->getLogger()->error(Language::get("recipe.save.failed", [$this->getPathname()]));
             Main::getInstance()->getLogger()->logException($e);


### PR DESCRIPTION
現在、 `RecipeManager::loadRecipes()` によってレシピが読み込まれるときに `Recipe::$rawData` にjsonの生データを設定し、 `Recipe::save()` が呼び出されるときに、それと一致する場合に書き込みを行わないことで同一データの書き込みを阻止していると思います。
しかし、レシピがセーブされた時に `Recipe::$rawData` は変更されないため、2回目以降の保存時にはこのメカニズムが正常に働かない(前回の保存時と同じデータが再度書き込みされる)か、以下のようなバグの発生に繋がります。

再現方法:
1. プラグインを起動する ( `RecipeManager::loadRecipes()` によってレシピがロードされる)
2. レシピの設定値を変更して保存する
3. レシピの設定値をプラグイン起動時と同じ値に戻して保存する
4. プラグインを再起動する
5. 手順3で設定値を戻しているにも関わらず、手順2で設定した設定値が復活している

このPRは、この問題を修正します。